### PR TITLE
Fix incorrect ordering of FlameParams tensor conversion

### DIFF
--- a/head_detector/head_info.py
+++ b/head_detector/head_info.py
@@ -96,8 +96,8 @@ class FlameParams:
             [
                 self.shape,
                 self.expression,
-                self.rotation,
                 self.jaw,
+                self.rotation,
                 self.eyeballs,
                 self.neck,
                 self.translation,


### PR DESCRIPTION
The method to_3dmm_tensor() of FlameParams yields the incorrect order. It doesn't affect the code since this method is never used, but I was using it.